### PR TITLE
Improved the release notes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.0.6"
+        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.1.0"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     }
 }

--- a/gradle/cd.gradle
+++ b/gradle/cd.gradle
@@ -24,8 +24,10 @@ task gitAddReleaseNotes(type: Exec) {
 task gitCommit(type: Exec) {
     description = "Commits staged changes using generic --author"
     mustRunAfter tasks.gitAddBumpVersion, tasks.gitAddReleaseNotes
-    commandLine = ["git", "commit", "--author", "Mockito Release Tools <mockito.release.tools@gmail.com>",
-                   "-m", commitMessage("Bumped version and updated release notes")]
+    doFirst {
+        commandLine = ["git", "commit", "--author", "$project.ext.genericGitUserName <$project.ext.genericGitUserEmail>",
+                       "-m", commitMessage("Bumped version and updated release notes")]
+    }
 }
 
 task gitTag(type: Exec) {
@@ -125,12 +127,16 @@ task checkOutBranch(type: Exec) {
 
 task configureGitUserName(type: Exec) {
     description = "Overwrites local git 'user.name' with a generic name. Intended for Travis CI."
-    commandLine = ["git", "config", "--local", "user.name", "Mockito Release Tools"]
+    doFirst {
+        commandLine = ["git", "config", "--local", "user.name", project.ext.genericGitUserName]
+    }
 }
 
 task configureGitUserEmail(type: Exec) {
     description = "Overwrites local git 'user.email' with a generic email. Intended for Travis CI."
-    commandLine = ["git", "config", "--local", "user.email", "mockito.release.tools@gmail.com"]
+    doFirst {
+        commandLine = ["git", "config", "--local", "user.email", project.ext.genericGitUserEmail]
+    }
 }
 
 tasks.withType(Exec) {

--- a/gradle/cd.gradle
+++ b/gradle/cd.gradle
@@ -16,8 +16,8 @@ task gitAddBumpVersion(type: Exec) {
 task gitAddReleaseNotes(type: Exec) {
     description = "Performs 'git add' for the release notes file"
     mustRunAfter tasks.updateReleaseNotes
-    doFirst { //so that we can access user-configured 'notesFile' property
-        commandLine = ["git", "add", notes.notesFile]
+    doFirst { //so that we can access user-configured 'releaseNotesFile' property
+        commandLine = ["git", "add", notes.releaseNotesFile]
     }
 }
 

--- a/gradle/cd.gradle
+++ b/gradle/cd.gradle
@@ -222,11 +222,7 @@ allprojects {
 
         bintrayUploadAll.dependsOn bintrayUpload
         bintrayUpload.doFirst {
-            it.apiKey = envVar('BINTRAY_API_KEY') //validates the presence of the env var
-
-            //Using doFirst so that we can pick up updated 'releaseDryRun' property
-            it.dryRun = rootProject.ext.has("releaseDryRun")
-
+            it.apiKey = envVar('BINTRAY_API_KEY') //validates the presence of the env var during execution phase
             logger.lifecycle "$path - publishing to Bintray (dry run: $it.dryRun)"
         }
 
@@ -238,10 +234,15 @@ allprojects {
             }
 
             publish = true
+            dryRun = rootProject.ext.has("releaseDryRun")
 
             pkg {
                 desc = project.description
                 publicDownloadNumbers = true
+
+                websiteUrl = "https://github.com/${notes.gitHubRepository}"
+                issueTrackerUrl = "https://github.com/${notes.gitHubRepository}/issues"
+                vcsUrl = "https://github.com/${notes.gitHubRepository}.git"
 
                 // optional version attributes
                 version {

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -10,10 +10,9 @@ notes {
 }
 
 ext {
-    genericGitAuthor = "Mockito Release Tools <mockito.release.tools@gmail.com>"
+    genericGitUserName = "Mockito Release Tools"
+    genericGitUserEmail = "<mockito.release.tools@gmail.com>"
     gitHubUser = "szczepiq"
-    //Travis CI uses shallow clone, loading extra commits for release notes (1.x -> 2.x had ~700 commits)
-    commitsToPullForTravis = 1000
     releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.
 }
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -16,6 +16,29 @@ ext {
     releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.
 }
 
+//TODO:
+//apply plugin: "org.mockito.release-tools.continuous-delivery"
+//continuousDelivery {
+//    releaseNotesFile = file("docs/release-notes.md")
+//    gitHubRepository = "mockito/mockito-release-tools-example"
+//    gitHubReadOnlyAuthToken = "e7fe8fcdd6ffed5c38498c4c79b2a68e6f6ed1bb" //read-only token
+//    gitHubLabelMapping = ["noteworthy": "Noteworthy", "bugfix": "Bugfixes"]
+//
+//    genericGitUserName = "Mockito Release Tools"
+//    genericGitUserEmail = "<mockito.release.tools@gmail.com>"
+//    gitHubUser = "szczepiq"
+//    releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.
+//}
+
+//TODO:
+//apply plugin: "org.mockito.release-tools.release-notes"
+//releaseNotes {
+//    releaseNotesFile = file("docs/release-notes.md")
+//    gitHubRepository = "mockito/mockito-release-tools-example"
+//    gitHubReadOnlyAuthToken = "e7fe8fcdd6ffed5c38498c4c79b2a68e6f6ed1bb" //read-only token
+//    gitHubLabelMapping = ["noteworthy": "Noteworthy", "bugfix": "Bugfixes"]
+//}
+
 allprojects {
     plugins.withId("com.jfrog.bintray") {
         bintray {
@@ -23,9 +46,6 @@ allprojects {
                 repo = 'mockito-release-tools-example-repo'
                 userOrg = 'mockito'
                 name = 'mockito-release-tools-example'
-                websiteUrl = 'http://mockito.org'
-                issueTrackerUrl = 'https://github.com/mockito/mockito-release-tools-example/issues'
-                vcsUrl = 'https://github.com/mockito/mockito-release-tools-example.git'
                 licenses = ['MIT']
                 labels = ['continuous delivery', 'release automation', 'mockito']
             }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -3,9 +3,9 @@ apply plugin: "org.mockito.release-tools.versioning"
 apply from: "gradle/cd.gradle"
 
 notes {
-    notesFile = file("docs/release-notes.md")
+    releaseNotesFile = file("docs/release-notes.md")
     gitHubRepository = "mockito/mockito-release-tools-example"
-    gitHubAuthToken = "e7fe8fcdd6ffed5c38498c4c79b2a68e6f6ed1bb" //read-only token
+    gitHubReadOnlyAuthToken = "e7fe8fcdd6ffed5c38498c4c79b2a68e6f6ed1bb" //read-only token
     gitHubLabelMapping = ["noteworthy": "Noteworthy", "bugfix": "Bugfixes"]
 }
 


### PR DESCRIPTION
- Updated version of release tools. This way, we can pick up the GitHub profile link improvement: https://github.com/mockito/mockito-release-tools/issues/12
- Updated implementation to use renamed API methods
- Some internal changes that will simplify exporting the implementation to new library
- Some design / commented-out code for how the future continuous delivery plugin will look like