### PR TITLE
Fixed problem with publication to notable repository

### DIFF
--- a/gradle/cd.gradle
+++ b/gradle/cd.gradle
@@ -208,7 +208,7 @@ task travisRelease {
 void performNotableRelease(boolean dryRun) {
     def v = project.version.toString()
     if (v.endsWith(".0") || v.endsWith(".0.0")) { //new minor or major version
-        logger.lifecycle "  It looks like we are realising a new notable version!\n" +
+        logger.lifecycle "  It looks like we are releasing a new notable version!\n" +
                 "  Performing additional upload to 'notable versions' repository and Maven Central."
 
         exec {

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -14,7 +14,7 @@ ext {
     genericGitUserEmail = "<mockito.release.tools@gmail.com>"
     gitHubUser = "szczepiq"
     releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.
-    bintray_repo = 'mockito-release-tools-example-repo'
+    bintray_repo = project.hasProperty('bintray_repo')? project.bintray_repo : 'mockito-release-tools-example-repo'
 }
 
 allprojects {

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -14,6 +14,8 @@ ext {
     genericGitUserEmail = "<mockito.release.tools@gmail.com>"
     gitHubUser = "szczepiq"
     releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.
+
+    //TODO all properties, not only bintray_repo, need to be overridable using command line or project property
     bintray_repo = project.hasProperty('bintray_repo')? project.bintray_repo : 'mockito-release-tools-example-repo'
 }
 

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=0.10.1
+version=0.11.0


### PR DESCRIPTION
Previous implementation did not allow overriding "bintray_repo" property from command line. We need this ability in order to make the publication to 'notable' repository.