### PR TITLE
Picked up a new version of release tools

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.1.4"
+        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.1.5"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     }
 }

--- a/gradle/cd.gradle
+++ b/gradle/cd.gradle
@@ -24,7 +24,7 @@ task gitAddReleaseNotes(type: Exec) {
     description = "Performs 'git add' for the release notes file"
     mustRunAfter tasks.updateReleaseNotes
     doFirst { //so that we can access user-configured 'releaseNotesFile' property
-        commandLine = ["git", "add", notes.releaseNotesFile]
+        commandLine = ["git", "add", project.ext.releaseNotes_file]
     }
 }
 
@@ -32,7 +32,7 @@ task gitCommit(type: Exec) {
     description = "Commits staged changes using generic --author"
     mustRunAfter tasks.gitAddBumpVersion, tasks.gitAddReleaseNotes
     doFirst {
-        commandLine = ["git", "commit", "--author", "$project.ext.genericGitUserName <$project.ext.genericGitUserEmail>",
+        commandLine = ["git", "commit", "--author", "$project.ext.git_genericUser <$project.ext.git_genericEmail>",
                        "-m", commitMessage("Bumped version and updated release notes")]
     }
 }
@@ -62,7 +62,7 @@ task gitPush {
             //!!!Below command _MUST_ be quiet otherwise it exposes GitHub write token!!!
             def mustBeQuiet = "-q"
             commandLine = ["git", "push",
-                           "https://${project.ext.gitHubUser}:${envVar('GH_TOKEN')}@github.com/${project.ext.gh_repository}.git",
+                           "https://${project.ext.gh_user}:${envVar('GH_TOKEN')}@github.com/${project.ext.gh_repository}.git",
                            envVar('TRAVIS_BRANCH'), "v$project.version", mustBeQuiet]
             if (rootProject.ext.has('releaseDryRun')) {
                 logger.lifecycle "  Running 'git push' with '--dry-run' in quiet mode."
@@ -135,14 +135,14 @@ task checkOutBranch(type: Exec) {
 task configureGitUserName(type: Exec) {
     description = "Overwrites local git 'user.name' with a generic name. Intended for Travis CI."
     doFirst {
-        commandLine = ["git", "config", "--local", "user.name", project.ext.genericGitUserName]
+        commandLine = ["git", "config", "--local", "user.name", project.ext.git_genericUser]
     }
 }
 
 task configureGitUserEmail(type: Exec) {
     description = "Overwrites local git 'user.email' with a generic email. Intended for Travis CI."
     doFirst {
-        commandLine = ["git", "config", "--local", "user.email", project.ext.genericGitUserEmail]
+        commandLine = ["git", "config", "--local", "user.email", project.ext.git_genericEmail]
     }
 }
 
@@ -175,7 +175,7 @@ task releaseNeeded {
         def skipEnvVariable = System.env.SKIP_RELEASE
         def skippedByCommitMessage = System.env.TRAVIS_COMMIT_MESSAGE?.contains('[ci skip-release]')
         def pullRequest = isPullRequest()
-        def releasableBranch = System.env.TRAVIS_BRANCH?.matches(project.ext.releasableBranchRegex)
+        def releasableBranch = System.env.TRAVIS_BRANCH?.matches(project.ext.git_releasableBranchRegex)
 
         if (skipEnvVariable || skippedByCommitMessage || pullRequest || !releasableBranch) {
             ext.needed = false

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -4,23 +4,22 @@ apply from: "gradle/cd.gradle"
 
 ext {
     gh_repository = "mockito/mockito-release-tools-example"
-    genericGitUserName = "Mockito Release Tools"
-    genericGitUserEmail = "<mockito.release.tools@gmail.com>"
-    gitHubUser = "szczepiq"
-    releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.
+    gh_user = "szczepiq"
+    gh_readOnlyAuthToken = "e7fe8fcdd6ffed5c38498c4c79b2a68e6f6ed1bb"
+    gh_writeAuthTokenEnvName = "GH_WRITE_TOKEN"
+
+    releaseNotes_file = "docs/release-notes.md"
+    releaseNotes_labelMapping = ["noteworthy": "Noteworthy", "bugfix": "Bugfixes"]
+
+    git_genericUser = "Mockito Release Tools"
+    git_genericEmail = "<mockito.release.tools@gmail.com>"
+    git_releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.
 
     //TODO all properties, not only bintray_repo, need to be overridable using command line or project property
     bintray_repo = project.hasProperty('bintray_repo')? project.bintray_repo : 'mockito-release-tools-example-repo'
 
     pom_developers = ['szczepiq:Szczepan Faber']
     pom_contributors = ['mstachniuk:Marcin Stachniuk']
-}
-
-notes {
-    releaseNotesFile = file("docs/release-notes.md")
-    gitHubRepository = project.ext.gh_repository
-    gitHubReadOnlyAuthToken = "e7fe8fcdd6ffed5c38498c4c79b2a68e6f6ed1bb" //read-only token
-    gitHubLabelMapping = ["noteworthy": "Noteworthy", "bugfix": "Bugfixes"]
 }
 
 allprojects {


### PR DESCRIPTION
Let's try using 'ext' properties instead of formal extension object. This way things are simple and a little bit more flexible. The solution however lacks type safety so we might eventually use formal extension type anyway.

Using 'ext' properties is more flexible because:
 - they don't depend on ordering of plugins (formal extension needs to be added first, then configured by other plugin or the user)
 - they naturally integrate with command line -P project properties and gradle.properties
 - they require less code to maintain within the release tools