### PR TITLE
Reduced the complexity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build/
+classes/
 
 # Ignore Gradle GUI config
 gradle-app.setting
@@ -12,3 +13,7 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+
+.idea/
+
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.2.0"
+        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.2.1"
     }
 }
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -13,10 +13,7 @@ ext {
     git_genericEmail = "<mockito.release.tools@gmail.com>"
     git_releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.
 
-    //TODO this conditional logic needs to be removed from here
-    // if 'bintray_notableRepo' not specified, we never release to notable repo
-    // if specified, we automatically configure stuff by passing internal parameter to the build
-    bintray_repo = project.hasProperty('bintray_repo')? project.bintray_repo : 'mockito-release-tools-example-repo'
+    bintray_repo = 'mockito-release-tools-example-repo'
     bintray_notableRepo = 'mockito-release-tools-example-repo-notable'
 
     pom_developers = ['szczepiq:Szczepan Faber']
@@ -25,7 +22,6 @@ ext {
 
 allprojects {
     plugins.withId("org.mockito.release-tools.bintray") {
-        rootProject.bintrayUploadAll.dependsOn project.tasks.bintrayUpload
         bintray {
             pkg {
                 user = 'szczepiq'


### PR DESCRIPTION
Picked up new version of release tools (pending merge of https://github.com/mockito/mockito-release-tools/pull/47) so that we can get rid of some complexity in the example repo.