### PR TITLE
Publishing notable versions to separate Bintray package instead of Bintray repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.3.9"
+        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.4.1"
     }
 }
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -15,11 +15,12 @@ ext {
     git_genericEmail = "<mockito.release.tools@gmail.com>"
     git_releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.
 
-    bintray_repo = 'mockito-release-tools-example-repo'
-    bintray_notableRepo = 'mockito-release-tools-example-repo-notable'
+    bintray_repo = 'examples'
+    bintray_pkg = 'basic-all-versions'
+    bintray_notablePkg = 'basic-notable-versions'
 
     pom_developers = ['szczepiq:Szczepan Faber']
-    pom_contributors = ['mstachniuk:Marcin Stachniuk']
+    pom_contributors = ['mstachniuk:Marcin Stachniuk', 'wwilk:Wojtek Wilk']
 }
 
 allprojects {
@@ -27,10 +28,9 @@ allprojects {
         bintray {
             pkg {
                 user = 'szczepiq'
-                userOrg = 'mockito'
-                name = 'mockito-release-tools-example'
+                userOrg = 'shipkit'
                 licenses = ['MIT']
-                labels = ['continuous delivery', 'release automation', 'mockito']
+                labels = ['continuous delivery', 'release automation', 'mockito', 'mockito-release-tools', 'shipkit']
             }
         }
     }

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=0.13.6
+version=0.14.0
 notableVersions=0.10.0, 0.7.1, 0.0.1


### PR DESCRIPTION
- More details about this change and the motivation: https://github.com/mockito/mockito-release-tools/pull/66
- Bumped version to pick up new version of tools (requires https://github.com/mockito/mockito-release-tools/pull/66 to be merged first), updated the configuration.