### PR TITLE
Fixed the release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.4.1"
+        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.5.0"
     }
 }
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -15,20 +15,19 @@ ext {
     git_genericEmail = "<mockito.release.tools@gmail.com>"
     git_releasableBranchRegex = "master|release/.+"  // matches 'master', 'release/2.x', 'release/3.x', etc.
 
-    bintray_repo = 'examples'
-    bintray_pkg = 'basic-all-versions'
-    bintray_notablePkg = 'basic-notable-versions'
-
     pom_developers = ['szczepiq:Szczepan Faber']
     pom_contributors = ['mstachniuk:Marcin Stachniuk', 'wwilk:Wojtek Wilk']
 }
 
 allprojects {
-    plugins.withId("org.mockito.release-tools.bintray") {
+    plugins.withId("org.mockito.mockito-release-tools.bintray") {
         bintray {
             pkg {
+                repo = 'examples'
                 user = 'szczepiq'
                 userOrg = 'shipkit'
+                //TODO we're making 'release_notable' project property public API here. Let's make it 'shipkit_notableRelease'.
+                name = project.ext.has('release_notable')? "basic-notable-versions" : "basic-all-versions"
                 licenses = ['MIT']
                 labels = ['continuous delivery', 'release automation', 'mockito', 'mockito-release-tools', 'shipkit']
             }

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=0.14.1
+version=0.15.0
 notableVersions=0.14.0, 0.10.0, 0.7.1, 0.0.1


### PR DESCRIPTION
- The rationale and motivation is outlined in the PR that needs to be merged first: https://github.com/mockito/mockito-release-tools/pull/68
- Removed some magic from the release so that all the Bintray related configuration logic is actually configured directly on the Bintray extension, rather than on our custom layer