### PR TITLE
Bumped release tools to 0.8.4 - concise release notes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        def toolsVer = "0.8.1"
+        def toolsVer = "0.8.4"
         classpath "gradle.plugin.org.mockito:mockito-release-tools:$toolsVer"
         println "  Using version '$toolsVer' of Mockito Release Tools"
     }

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,3 @@
 version=0.15.3
 notableVersions=0.15.0, 0.14.0, 0.10.0, 0.7.1, 0.0.1
+previousVersion=0.15.2


### PR DESCRIPTION
1. Bumped version of tools.
 - The main improvement that is picked up is concise format of release notes: mockito/mockito-release-tools#108
 - Also picked up some internal refactorings of release tools. The previous version number will be automatically bumped / added to version.properties file.

@mstachniuk, @wwilk, this PR is basically the same as the PR I submitted to mockito: https://github.com/mockito/mockito/pull/1069 It would be awesome if had this automated, e.g. @mstachniuk's idea of automatically pushing versions - https://github.com/mockito/mockito-release-tools/issues/85 @mstachniuk, we need your codes :)