### PR TITLE
Clean up shipkit Gradle plugin names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,6 @@ allprojects {
     group = "org.mockito.release-tools-example"
 }
 
-apply plugin: "org.shipkit.continuous-delivery"
+apply plugin: "org.shipkit.java"
 
 apply from: "gradle/ide.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.8.60"
+        classpath "gradle.plugin.org.mockito:mockito-release-tools:0.8.61"
     }
 }
 

--- a/subprojects/api/build.gradle
+++ b/subprojects/api/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: "org.shipkit.java-library"
 apply plugin: "org.shipkit.publications-comparator"
 
 dependencies {

--- a/subprojects/impl/build.gradle
+++ b/subprojects/impl/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: "org.shipkit.java-library"
 apply plugin: "org.shipkit.publications-comparator"
 
 dependencies {


### PR DESCRIPTION
Basically, making use of the new plugin name.
No need to apply `org.shipkit.java-library` to every subproject any longer.