### PR TITLE
Bumped Shipkit + tidy-up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "org.shipkit:shipkit:0.9.31"
+        classpath "org.shipkit:shipkit:0.9.38"
     }
 }
 

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,16 +1,7 @@
-//TODO let's make this project use all possible configuration options
-//and create a separate example project that would rely on default (minimum example)
 shipkit {
     gitHub.repository = "mockito/shipkit-example"
     gitHub.readOnlyAuthToken = "e7fe8fcdd6ffed5c38498c4c79b2a68e6f6ed1bb"
 
-    //TODO find out if we really need to provide write auth user given taht we use the token
-    gitHub.writeAuthUser = "shipkit"
-
-    //TODO default below 3 settings inside the tools
-    git.user = "Shipkit"
-    git.email = "<mockito.release.tools@gmail.com>"
-    releaseNotes.file = "docs/release-notes.md"
     releaseNotes.ignoreCommitsContaining = ["[ci skip]"]
 
     team.developers = ['szczepiq:Szczepan Faber', 'mstachniuk:Marcin Stachniuk', 'wwilk:Wojtek Wilk']
@@ -22,8 +13,7 @@ allprojects {
             pkg {
                 repo = 'examples'
                 user = 'szczepiq'
-                userOrg = 'shipkit'
-                //TODO let's default the package name to the org
+                userOrg = 'shipkit'                
                 name = "basic"
                 licenses = ['MIT']
                 labels = ['continuous delivery', 'release automation', 'mockito', 'shipkit']
@@ -32,9 +22,9 @@ allprojects {
     }
 }
 
-apply plugin: 'org.shipkit.version-upgrade-consumer'
+apply plugin: 'org.shipkit.upgrade-dependency'
 
-versionUpgrade{
+upgradeDependency {
     baseBranch = "master"
     buildFile = file("build.gradle")
 }


### PR DESCRIPTION
1. Removed unnecessary code from shipkit.gradle file. Less configuration -> less complexity.
2. Bumped Shipkit version to latest
3. Updated the usage of upgrade-dependency plugin so that it builds

Tested by running "./gradlew testRelease". All good!