### PR TITLE
Bumped Shipkit and updated plugin id

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "org.shipkit:shipkit:0.9.63"
+        classpath "org.shipkit:shipkit:0.9.73"
     }
 }
 

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -8,7 +8,7 @@ shipkit {
 }
 
 allprojects {
-    plugins.withId("org.shipkit.bintray") {
+    plugins.withId("com.jfrog.bintray") {
         bintray {
             pkg {
                 repo = 'examples'


### PR DESCRIPTION
I think it is simpler if we use a plugin that is well documented and known, instead of our own plugin for now.

Tested by invoking "./gradlew testRelease"