### PR TITLE
increase version manually

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-version=0.16.16
+version=0.16.17
 previousVersion=0.16.15


### PR DESCRIPTION
because it looks like we do have a tag for 0.16.16 but actually no 0.16.16 release happened.